### PR TITLE
Change to 'print' and 'sendall' for Python 3.4

### DIFF
--- a/part1/webserver1.py
+++ b/part1/webserver1.py
@@ -10,12 +10,12 @@ print 'Serving HTTP on port %s ...' % PORT
 while True:
     client_connection, client_address = listen_socket.accept()
     request = client_connection.recv(1024)
-    print request
+    print (request)
 
     http_response = """\
 HTTP/1.1 200 OK
 
 Hello, World!
 """
-    client_connection.sendall(http_response)
+    client_connection.sendall(bytes(http_response, "utf-8"))
     client_connection.close()


### PR DESCRIPTION
I had to make these changes to have the code run in Python 3.4. 'Print' requires parens and 'sendall' requires conversion of string to bytes.
